### PR TITLE
fix(ci): skip examples during addon packaging

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,4 +70,6 @@ jobs:
           target-branch: "godot-v${{ steps.version.outputs.major-minor }}"
           godot-editor-version: "v${{ steps.version.outputs.semantic }}"
           file-excludes: |
+            **/example
+            **/examples
             **/*_test.gd


### PR DESCRIPTION
This is motivated by the fact that the example scenes reference other project files by the root-based paths (i.e. pre-packaging paths). This breaks the scenes when imported in an external project.