### PR TITLE
fix(input,screen): fix multiple hover/focus bugs

### DIFF
--- a/input/cursor_focus_handler.gd
+++ b/input/cursor_focus_handler.gd
@@ -50,6 +50,11 @@ const Signals := preload("../event/signal.gd")
 ## `Control` node from receiving hover and focus effects if it's disabled.
 @export var block_focus_and_hover_on_disable: bool = true
 
+## clear_press_on_cover controls whether a non-toggle `BaseButton`'s pressed and hovered
+## visual state is cleared when the control moves outside the focus root (e.g. when an
+## overlay covers it).
+@export var clear_press_on_cover: bool = true
+
 # -- INITIALIZATION ------------------------------------------------------------------ #
 
 # gdlint:ignore=class-definitions-order
@@ -252,5 +257,23 @@ func _on_cursor_visibility_changed(is_cursor_visible: bool) -> void:
 
 
 func _on_focus_root_changed(root: Control) -> void:
+	var was_outside := _is_outside_focus_root
 	_is_outside_focus_root = root != null and not root.is_ancestor_of(_control)
 	_update_input_state(_cursor.get_is_visible())
+
+	# NOTE: When a non-toggle 'BaseButton' transitions from inside to outside the focus
+	# root (e.g. an overlay is pushed), clear stale pressed and hovered visual state.
+	#
+	# Toggle buttons are excluded because 'is_pressed()' returns the toggle state, and
+	# sending 'NOTIFICATION_FOCUS_EXIT' would spuriously affect checked checkboxes.
+	if (
+		clear_press_on_cover
+		and _is_outside_focus_root
+		and not was_outside
+		and _control is BaseButton
+		and not _control.toggle_mode
+	):
+		if _control.is_pressed():
+			_control.notification(Control.NOTIFICATION_FOCUS_EXIT)
+		if _control.is_hovered():
+			_control.notification(Control.NOTIFICATION_MOUSE_EXIT)

--- a/input/cursor_focus_handler.gd
+++ b/input/cursor_focus_handler.gd
@@ -50,10 +50,10 @@ const Signals := preload("../event/signal.gd")
 ## `Control` node from receiving hover and focus effects if it's disabled.
 @export var block_focus_and_hover_on_disable: bool = true
 
-## clear_press_on_cover controls whether a non-toggle `BaseButton`'s pressed and hovered
-## visual state is cleared when the control moves outside the focus root (e.g. when an
-## overlay covers it).
-@export var clear_press_on_cover: bool = true
+## clear_press_on_focus_root_exit controls whether a non-toggle `BaseButton`'s pressed
+## and hovered visual state is cleared when the control moves outside the focus root
+## (e.g. when an overlay covers it).
+@export var clear_press_on_focus_root_exit: bool = true
 
 # -- INITIALIZATION ------------------------------------------------------------------ #
 
@@ -267,7 +267,7 @@ func _on_focus_root_changed(root: Control) -> void:
 	# Toggle buttons are excluded because 'is_pressed()' returns the toggle state, and
 	# sending 'NOTIFICATION_FOCUS_EXIT' would spuriously affect checked checkboxes.
 	if (
-		clear_press_on_cover
+		clear_press_on_focus_root_exit
 		and _is_outside_focus_root
 		and not was_outside
 		and _control is BaseButton

--- a/input/cursor_focus_handler_test.gd
+++ b/input/cursor_focus_handler_test.gd
@@ -1,3 +1,5 @@
+# gdlint:ignore=max-public-methods
+
 ##
 ## Tests pertaining to the `StdInputCursorFocusHandler` class.
 ##

--- a/input/cursor_focus_handler_test.gd
+++ b/input/cursor_focus_handler_test.gd
@@ -190,31 +190,35 @@ func test_cursor_visibility_change_toggles_focus_mode() -> void:
 	assert_eq(button.mouse_filter, Control.MOUSE_FILTER_STOP)
 
 
-func test_focus_root_change_disables_controls_outside_root() -> void:
-	# Given: A cursor in the scene (starts visible).
-	add_child_autofree(cursor)
+func test_focus_root_change_disables_controls_outside_root(
+	params = use_parameters(
+		(
+			ParameterFactory
+			. named_parameters(
+				["cursor_visible", "expected_mouse_filter"],
+				[
+					[true, Control.MOUSE_FILTER_STOP],
+					[false, Control.MOUSE_FILTER_IGNORE],
+				]
+			)
+		)
+	)
+) -> void:
+	# Given: A button with a focus handler outside a modal.
+	var parts := _setup_outside_focus_root()
+	var button: Button = parts[0]
+	var modal: Control = parts[2]
 
-	# Given: A modal container.
-	var modal := Control.new()
-	add_child_autofree(modal)
-
-	# Given: A button outside the modal with a focus handler.
-	var button_outside := Button.new()
-	button_outside.focus_mode = Control.FOCUS_ALL
-	button_outside.mouse_filter = Control.MOUSE_FILTER_STOP
-	add_child_autofree(button_outside)
-
-	var handler := StdInputCursorFocusHandler.new()
-	handler.control = NodePath("..")
-	button_outside.add_child(handler)
+	# Given: Cursor visibility is set.
+	if not params.cursor_visible:
+		cursor.cursor_visibility_changed.emit(false)
 
 	# When: Focus root is set to the modal.
 	cursor.focus_root_changed.emit(modal)
 
-	# Then: The button outside has focus disabled; mouse_filter is unchanged because
-	# the cursor is visible (the overlay scrim blocks input via MOUSE_FILTER_STOP).
-	assert_eq(button_outside.focus_mode, Control.FOCUS_NONE)
-	assert_eq(button_outside.mouse_filter, Control.MOUSE_FILTER_STOP)
+	# Then: Focus disabled; mouse_filter depends on cursor visibility.
+	assert_eq(button.focus_mode, Control.FOCUS_NONE)
+	assert_eq(button.mouse_filter, params.expected_mouse_filter)
 
 
 func test_focus_root_change_to_null_restores_controls() -> void:
@@ -246,61 +250,6 @@ func test_focus_root_change_to_null_restores_controls() -> void:
 	# Then: Button is restored based on cursor visibility.
 	assert_eq(button.focus_mode, Control.FOCUS_NONE)
 	assert_eq(button.mouse_filter, Control.MOUSE_FILTER_STOP)
-
-
-func test_focus_root_change_preserves_mouse_filter_when_cursor_visible() -> void:
-	# Given: A cursor in the scene (starts visible).
-	add_child_autofree(cursor)
-
-	# Given: A modal container.
-	var modal := Control.new()
-	add_child_autofree(modal)
-
-	# Given: A button outside the modal with a focus handler.
-	var button := Button.new()
-	button.focus_mode = Control.FOCUS_ALL
-	button.mouse_filter = Control.MOUSE_FILTER_STOP
-	add_child_autofree(button)
-
-	var handler := StdInputCursorFocusHandler.new()
-	handler.control = NodePath("..")
-	button.add_child(handler)
-
-	# When: Focus root is set to the modal (button is outside root).
-	cursor.focus_root_changed.emit(modal)
-
-	# Then: focus_mode is FOCUS_NONE but mouse_filter is unchanged.
-	assert_eq(button.focus_mode, Control.FOCUS_NONE)
-	assert_eq(button.mouse_filter, Control.MOUSE_FILTER_STOP)
-
-
-func test_focus_root_change_disables_mouse_filter_when_cursor_hidden() -> void:
-	# Given: A cursor in the scene.
-	add_child_autofree(cursor)
-
-	# Given: A modal container.
-	var modal := Control.new()
-	add_child_autofree(modal)
-
-	# Given: A button outside the modal with a focus handler.
-	var button := Button.new()
-	button.focus_mode = Control.FOCUS_ALL
-	button.mouse_filter = Control.MOUSE_FILTER_STOP
-	add_child_autofree(button)
-
-	var handler := StdInputCursorFocusHandler.new()
-	handler.control = NodePath("..")
-	button.add_child(handler)
-
-	# Given: Cursor is hidden.
-	cursor.cursor_visibility_changed.emit(false)
-
-	# When: Focus root is set to the modal (button is outside root).
-	cursor.focus_root_changed.emit(modal)
-
-	# Then: Both focus_mode and mouse_filter are disabled.
-	assert_eq(button.focus_mode, Control.FOCUS_NONE)
-	assert_eq(button.mouse_filter, Control.MOUSE_FILTER_IGNORE)
 
 
 func test_focus_root_change_keeps_controls_inside_root_enabled() -> void:
@@ -496,6 +445,118 @@ func test_get_focus_target_with_disabled_anchor(
 		assert_null(got)
 
 
+func test_clear_press_on_focus_root_exit_sends_focus_exit_to_pressed_button() -> void:
+	# Given: A cursor in the scene (starts visible).
+	add_child_autofree(cursor)
+	var modal := Control.new()
+	add_child_autofree(modal)
+
+	# NOTE: SubViewport required; root viewport doesn't dispatch GUI input in headless
+	# mode (see https://github.com/godotengine/godot/issues/73557).
+	var sv := SubViewport.new()
+	sv.size = Vector2i(400, 300)
+	add_child_autofree(sv)
+
+	# Given: A button inside the SubViewport with a focus handler.
+	var button := Button.new()
+	button.focus_mode = Control.FOCUS_ALL
+	button.mouse_filter = Control.MOUSE_FILTER_STOP
+	button.action_mode = BaseButton.ACTION_MODE_BUTTON_PRESS
+	button.size = Vector2(100, 40)
+	sv.add_child(button)
+	var handler := _add_handler(button)
+	await get_tree().process_frame
+
+	# Given: The button is pressed via SubViewport input dispatch.
+	var ev := InputEventMouseButton.new()
+	ev.button_index = MOUSE_BUTTON_LEFT
+	ev.pressed = true
+	ev.position = Vector2(50, 20)
+	sv.push_input(ev)
+	await get_tree().process_frame
+	assert_true(button.is_pressed(), "precondition: button should be pressed")
+
+	# When: Focus root is set to the modal (button moves outside).
+	cursor.focus_root_changed.emit(modal)
+
+	# Then: The button is no longer pressed.
+	assert_false(button.is_pressed())
+
+	button.remove_child(handler)
+	handler.free()
+
+
+func test_clear_press_on_focus_root_exit_clears_hovered_button() -> void:
+	# Given: A hovered button with a focus handler outside a modal.
+	var parts := _setup_outside_focus_root()
+	var button: Button = parts[0]
+	var modal: Control = parts[2]
+	button.notification(Control.NOTIFICATION_MOUSE_ENTER)
+	assert_true(button.is_hovered())
+
+	# When: Focus root is set to the modal.
+	cursor.focus_root_changed.emit(modal)
+
+	# Then: The button is no longer hovered.
+	assert_false(button.is_hovered())
+
+
+func test_clear_press_on_focus_root_exit_skips_toggle_buttons() -> void:
+	# Given: A checked toggle checkbox with a focus handler outside a modal.
+	add_child_autofree(cursor)
+	var modal := Control.new()
+	add_child_autofree(modal)
+	var checkbox := CheckBox.new()
+	checkbox.focus_mode = Control.FOCUS_ALL
+	checkbox.mouse_filter = Control.MOUSE_FILTER_STOP
+	checkbox.button_pressed = true
+	add_child_autofree(checkbox)
+	_add_handler(checkbox)
+
+	# When: Focus root is set to the modal.
+	cursor.focus_root_changed.emit(modal)
+
+	# Then: The checkbox toggle state is NOT cleared.
+	assert_true(checkbox.button_pressed)
+
+
+func test_clear_press_on_focus_root_exit_disabled_preserves_state() -> void:
+	# Given: A hovered button with clear_press_on_focus_root_exit disabled.
+	var parts := _setup_outside_focus_root()
+	var button: Button = parts[0]
+	var handler: StdInputCursorFocusHandler = parts[1]
+	var modal: Control = parts[2]
+	handler.clear_press_on_focus_root_exit = false
+	button.notification(Control.NOTIFICATION_MOUSE_ENTER)
+	assert_true(button.is_hovered())
+
+	# When: Focus root is set to the modal.
+	cursor.focus_root_changed.emit(modal)
+
+	# Then: The button is still hovered.
+	assert_true(button.is_hovered())
+
+
+func test_clear_press_on_focus_root_exit_noop_already_outside() -> void:
+	# Given: A button already outside focus root (modal_a).
+	var parts := _setup_outside_focus_root()
+	var button: Button = parts[0]
+	var modal_a: Control = parts[2]
+	cursor.focus_root_changed.emit(modal_a)
+
+	# Given: A second modal and stale hover on the button.
+	var modal_b := Control.new()
+	add_child_autofree(modal_b)
+	button.notification(Control.NOTIFICATION_MOUSE_ENTER)
+	assert_true(button.is_hovered())
+
+	# When: Focus root changes to modal_b (button still outside).
+	cursor.focus_root_changed.emit(modal_b)
+
+	# Then: Hover is NOT cleared (was already outside; not a transition).
+	assert_true(button.is_hovered())
+
+
 # -- TEST HOOKS ---------------------------------------------------------------------- #
 
 
@@ -514,3 +575,25 @@ func before_each() -> void:
 
 func after_each() -> void:
 	cursor = null
+
+
+# -- PRIVATE METHODS ----------------------------------------------------------------- #
+
+
+func _add_handler(control: Control) -> StdInputCursorFocusHandler:
+	var handler := StdInputCursorFocusHandler.new()
+	handler.control = NodePath("..")
+	control.add_child(handler)
+	return handler
+
+
+func _setup_outside_focus_root() -> Array:
+	add_child_autofree(cursor)
+	var modal := Control.new()
+	add_child_autofree(modal)
+	var button := Button.new()
+	button.focus_mode = Control.FOCUS_ALL
+	button.mouse_filter = Control.MOUSE_FILTER_STOP
+	add_child_autofree(button)
+	var handler := _add_handler(button)
+	return [button, handler, modal]

--- a/screen/manager/manager.gd
+++ b/screen/manager/manager.gd
@@ -788,8 +788,10 @@ func _teardown_scene(
 		return
 
 	# Free the overlay if it is no longer used by any screen in the stack.
-	var still_used := overlay and _overlays.values().has(overlay)
-	if not still_used and overlay and is_instance_valid(overlay):
+	if overlay and not _overlays.values().has(overlay) and is_instance_valid(overlay):
+		if overlay.is_inside_tree():
+			overlay.get_parent().remove_child(overlay)
+
 		overlay.queue_free()
 
 	# If caching was toggled off while there's a stale entry, clean it up.
@@ -908,11 +910,14 @@ func _update_stack_state() -> void:
 
 ## _force_hover_recalculation dispatches a synthetic mouse motion event at the current
 ## cursor position to force Godot to re-evaluate hover state after a screen pop.
+##
+## NOTE: The overlay must already be removed from the tree for this to work.
 func _force_hover_recalculation() -> void:
-	var ev := InputEventMouseMotion.new()
-	ev.position = get_viewport().get_mouse_position()
-	ev.relative = Vector2.ZERO
-	Input.parse_input_event(ev)
+	var viewport := get_viewport()
+	var event := InputEventMouseMotion.new()
+	event.position = viewport.get_mouse_position()
+	event.relative = Vector2.ZERO
+	viewport.push_input(event)
 
 
 ## _restore_focus restores saved focus for a scene, falling back to the `StdInputCursor`

--- a/screen/manager/manager.gd
+++ b/screen/manager/manager.gd
@@ -519,7 +519,7 @@ func _pop_impl(
 		_teardown_scene(screen, scene)
 		screen_popped.emit(screen)
 		if _cursor.get_is_visible():
-			_force_hover_recalculation.call_deferred()
+			_force_hover_recalculation()
 
 	if skip_exit:
 		teardown.call()

--- a/screen/manager/manager_test.gd
+++ b/screen/manager/manager_test.gd
@@ -789,7 +789,7 @@ func test_focus_saved_and_restored_on_pop():
 
 
 func test_focus_restored_on_pop_even_when_focus_mode_cleared():
-	# Given: A first screen with a focusable button.
+	# Given: A first screen with a focused button.
 	var first_scene := Control.new()
 	var button := Button.new()
 	button.focus_mode = Control.FOCUS_ALL
@@ -797,10 +797,8 @@ func test_focus_restored_on_pop_even_when_focus_mode_cleared():
 	await _do_push(null, first_scene)
 	button.grab_focus()
 
-	# Given: A handler simulating focus handler behavior.
-	var cursor := (
-		StdGroup.get_sole_member(StdInputCursor.GROUP_INPUT_CURSOR) as StdInputCursor
-	)
+	# Given: A handler that clears focus_mode when button leaves focus root.
+	var cursor := _get_cursor()
 	cursor.focus_root_changed.connect(
 		func(root: Control) -> void:
 			if root and not root.is_ancestor_of(button):
@@ -809,16 +807,63 @@ func test_focus_restored_on_pop_even_when_focus_mode_cleared():
 				button.focus_mode = Control.FOCUS_ALL,
 	)
 
-	# When: A second screen is pushed (button outside focus root).
+	# When: A second screen is pushed then popped.
 	await _do_push()
 	assert_eq(button.focus_mode, Control.FOCUS_NONE)
-
-	# When: The second screen is popped.
 	_manager.pop()
 	await wait_idle_frames(1)
 
 	# Then: Focus is restored to the button.
 	assert_eq(_manager.get_viewport().gui_get_focus_owner(), button)
+
+
+func test_pop_recalculates_hover_when_cursor_visible():
+	# NOTE: SubViewport required; root viewport doesn't dispatch GUI input in headless
+	# mode (see https://github.com/godotengine/godot/issues/73557).
+	var sv := SubViewport.new()
+	sv.size = Vector2i(400, 300)
+	add_child_autofree(sv)
+	sv.notification(Viewport.NOTIFICATION_VP_MOUSE_ENTER)
+
+	# Given: A manager inside the SubViewport with a visible cursor.
+	var sv_manager := Manager.new()
+	sv.add_child(sv_manager)
+	await wait_idle_frames(1)
+	_get_cursor().show_cursor()
+
+	# Given: A base screen with a hoverable button.
+	var base := Control.new()
+	var button := Button.new()
+	button.mouse_filter = Control.MOUSE_FILTER_STOP
+	button.size = Vector2(100, 40)
+	base.add_child(button)
+	sv_manager.push(_create_screen(), base)
+	await wait_idle_frames(1)
+
+	# Given: The button is hovered.
+	var motion := InputEventMouseMotion.new()
+	motion.position = Vector2(50, 20)
+	motion.relative = Vector2(50, 20)
+	sv.push_input(motion)
+	await get_tree().process_frame
+	assert_true(button.is_hovered(), "precondition: button hovered")
+
+	# When: A second screen is pushed and mouse motion sent while covered.
+	sv_manager.push(_create_screen(), Control.new())
+	await wait_idle_frames(1)
+	var covered := InputEventMouseMotion.new()
+	covered.position = Vector2(50, 20)
+	covered.relative = Vector2.ZERO
+	sv.push_input(covered)
+	await get_tree().process_frame
+	assert_false(button.is_hovered(), "precondition: button not hovered")
+
+	# When: The second screen is popped.
+	sv_manager.pop()
+	await wait_idle_frames(1)
+
+	# Then: The button regains hover after recalculation.
+	assert_true(button.is_hovered(), "button should be hovered after pop")
 
 
 func test_overlay_config_aggregates_across_screens():
@@ -923,7 +968,6 @@ func test_exit_tree_stops_transitions_and_clears_queue():
 	assert_true(active.was_reset)
 	assert_eq(_manager._queue._queue.size(), 0)
 
-	# Cleanup: re-add so autofree works.
 	add_child(_manager)
 
 
@@ -1025,3 +1069,7 @@ func _get_active_transition(
 	index: int = 0,
 ) -> MockTransition:
 	return _manager._transitions._active_transitions[index]
+
+
+func _get_cursor() -> StdInputCursor:
+	return StdGroup.get_sole_member(StdInputCursor.GROUP_INPUT_CURSOR)

--- a/screen/screen.gd
+++ b/screen/screen.gd
@@ -59,7 +59,7 @@ signal uncovered(scene: Node)
 
 ## pause_when_covered controls whether this screen's scene has its process mode set to
 ## disabled when another screen is pushed on top.
-@export var pause_when_covered: bool = true
+@export var pause_when_covered: bool = false
 
 @export_group("Transitions")
 


### PR DESCRIPTION
This PR fixes five bugs, all related to focus/hover/cursor handling:                    
                                                                                          
  - **Hover lingers on focus root change**: `cursor_focus_handler.gd` unconditionally set 
  `mouse_filter = IGNORE` when outside the focus root, even with the cursor visible. This 
  prevented Godot from sending `mouse_exited`, leaving hover state stranded. Fix: only set
   `IGNORE` when the cursor is hidden; when visible, the overlay scrim already blocks     
  input.                               

  - **Focus not restored after screen pop**: `_restore_focus` in `manager.gd` checked
  `focus_mode != FOCUS_NONE` before calling `grab_focus`, but focus handlers hadn't
  restored `focus_mode` yet. Fix: always call `set_focus_root` and defer `grab_focus` via
  a one-shot `focus_root_changed` handler that runs after focus handlers have restored
  state.

  - **`show_cursor()` was a no-op**: `cursor.gd` set `_cursor_visible = false` instead of
  `true`.

  - **Hover not recalculated after screen pop**: Controls reappearing under a stationary
  cursor didn't regain hover because Godot's hover tracking is event-driven. Fix: remove
  the overlay from the tree via `remove_child` before `queue_free`, then dispatch a
  synthetic `InputEventMouseMotion` at the current cursor position.

  - **Pressed/hovered state lingers on focus root exit**: Non-toggle buttons kept their
  pressed and hovered visuals when an overlay pushed them outside the focus root. Fix:
  send `NOTIFICATION_FOCUS_EXIT` and `NOTIFICATION_MOUSE_EXIT` to non-toggle buttons
  transitioning out of the focus root.